### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dataloader": "^1.2.0",
     "express": "^4.14.0",
     "express-graphql": "^0.5.4",
-    "graphql": "^0.7.2",
+    "graphql": "*",
     "jsontableschema": "^0.2.2",
     "knex": "^0.12.6",
     "lodash": "^4.16.4",

--- a/package.json
+++ b/package.json
@@ -64,8 +64,5 @@
     "js-beautify": "^1.6.4",
     "mocha": "^3.1.2",
     "sqlite3": "^3.1.8"
-  },
-  "engines": {
-    "node": "6.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dataloader": "^1.2.0",
     "express": "^4.14.0",
     "express-graphql": "^0.5.4",
-    "graphql": "*",
+    "graphql": "^0.7.2",
     "jsontableschema": "^0.2.2",
     "knex": "^0.12.6",
     "lodash": "^4.16.4",


### PR DESCRIPTION
The version constraint prevents installation with a newer version. I propose removing it entirely, but if you want to specify a more flexible version bound, that's a good solution too.